### PR TITLE
Fix for "429 Too Many Requests" responses 

### DIFF
--- a/stalenhag.py
+++ b/stalenhag.py
@@ -96,21 +96,21 @@ def get_images_list(prints=False):
 def download_image(image):
     url = f'{BASE}{image}'
     r = requests.get(url)
-    if r.status_code == 200:
-        with open(IMAGES_DIR + image.replace('/', '-'), 'wb') as f:
-            for chunk in r:
-                f.write(chunk)
+    if r.status_code == 429:
         try:
             rtry = r.headers['Retry-After']
             if rtry:
                 sleep(int(rtry))
+                r = requests.get(url)
         except (TypeError, ValueError):
             print('Error converting retry value to int')
             sleep(0.5)
+            r = requests.get(url)
             return
-        except:
-            # No Retry-After header
-            return
+
+    with open(IMAGES_DIR + image.replace('/', '-'), 'wb') as f:
+        for chunk in r:
+            f.write(chunk)
 
 def get_random_local_image(favorites=False):
     images = []

--- a/stalenhag.py
+++ b/stalenhag.py
@@ -10,6 +10,7 @@ BASE = 'http://www.simonstalenhag.se/'
 class Pages(Enum):
     ALL = ''
     STEEL_MEADOW = BASE
+    SWEDISH_MACHINES = f'{BASE}svema.html'
     PALEOART = f'{BASE}paleo.html'
     COMMISIONS = f'{BASE}other.html'
     TALES_FROM_THE_LOOP = f'{BASE}tftl.html'
@@ -19,6 +20,7 @@ class Pages(Enum):
 
 class Collections(Enum):
     ALL = 'ALL'
+    SWEDISH_MACHINES = 'SWEDISH_MACHINES'
     STEEL = 'STEEL_MEADOW'
     PALEO = 'PALEOART'
     OTHERS = 'COMMISIONS'
@@ -83,7 +85,7 @@ def get_images_list(prints=False):
     images = []
     for url in urls:
         contents = request.urlopen(url).read()
-        search = r'(?:bilder|paleo|other|tftl|tftf)big\/[a-zA-Z0-9_]*\.jpg'
+        search = r'(?:4k)?/(?:bilder|svema|other|tftl|tftf)_?\d*_?big\.jpg|(?:/4k/)?(?:bilder|svema|other|tftl|tftf)big/\d+\.jpg|(?:bilder|paleo|other|tftl|tftf)big\/[a-zA-Z0-9_]*\.jpg'
         collectionImages = re.findall(search, str(contents))
         images.extend(collectionImages)
 


### PR DESCRIPTION
When running the script I had issues downloading images and got a 429 response. It will now check if there is a Retry-After header in the response, and apply a sleep duration from that. 

Also changed the url to use https base url. 